### PR TITLE
Added exceptions to notify about error conditions

### DIFF
--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -1,5 +1,16 @@
 #include "Modbus.h"
 
+const char STR_NO_EXCEPTION[] = "";
+const char STR_TIMEOUT_EXCEPTION[] = "timeout";
+const char STR_OVERFLOW_EXCEPTION[] = "overflow";
+const char STR_INVALID_TRANSACTION_ID_EXCEPTION[] = "transaction id";
+const char STR_INVALID_PROTOCOL_ID_EXCEPTION[] = "protocol id";
+const char STR_BAD_SLAVE_ERROR_EXCEPTION[] = "bad slave error";
+const char STR_BAD_FUNCTION_CODE_EXCEPTION[] = "bad function code";
+const char STR_BAD_DATA_LENGTH_EXCEPTION[] = "bad data length";
+const char STR_CRC_EXCEPTION[] = "invalid crc";
+const char STR_UNKNOWN_EXCEPTION[] = "unknown exception";
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ModbusFrame::ModbusFrame(uint8_t slave, uint8_t *pdu) {
 	_slave = slave;

--- a/src/Modbus.h
+++ b/src/Modbus.h
@@ -7,6 +7,17 @@
 #define MODBUS_PDU_SIZE 				(1 + MODBUS_DATA_SIZE) // PDU = FC (1) + DATA
 #define MODBUS_RESPONSE_TIMEOUT			1000
 
+extern const char STR_NO_EXCEPTION[];
+extern const char STR_TIMEOUT_EXCEPTION[];
+extern const char STR_OVERFLOW_EXCEPTION[];
+extern const char STR_INVALID_TRANSACTION_ID_EXCEPTION[];
+extern const char STR_INVALID_PROTOCOL_ID_EXCEPTION[];
+extern const char STR_BAD_SLAVE_ERROR_EXCEPTION[];
+extern const char STR_BAD_FUNCTION_CODE_EXCEPTION[];
+extern const char STR_BAD_DATA_LENGTH_EXCEPTION[];
+extern const char STR_CRC_EXCEPTION[];
+extern const char STR_UNKNOWN_EXCEPTION[];
+
 class ModbusDevice {
 	public:
 		enum FunctionCodes {
@@ -27,11 +38,77 @@ class ModbusDevice {
 			ServerDeviceFailure		= 0x04,
 		};
 
+		enum Exceptions {
+			NoException = 0,
+			TimeoutException,
+			OverflowException,
+			InvalidTransactionIdException,
+			InvalidProtocolIdException,
+			BadSlaveErrorException,
+			BadFunctionCodeException,
+			BadDataLengthException,
+			BadCRCException
+		};
+
+		const char* getExceptionMessage() {
+			return getExceptionMessage(_exception);
+		}
+
+		const char* getExceptionMessage(enum Exceptions e) {
+			switch(e) {
+				case NoException:
+					return STR_NO_EXCEPTION;
+				break;
+				case TimeoutException:
+					return STR_TIMEOUT_EXCEPTION;
+				break;
+				case OverflowException:
+					return STR_OVERFLOW_EXCEPTION;
+				break;
+				case InvalidTransactionIdException:
+					return STR_INVALID_TRANSACTION_ID_EXCEPTION;
+				break;
+				case InvalidProtocolIdException:
+					return STR_INVALID_PROTOCOL_ID_EXCEPTION;
+				break;
+				case BadSlaveErrorException:
+					return STR_BAD_SLAVE_ERROR_EXCEPTION;
+				break;
+				case BadFunctionCodeException:
+					return STR_BAD_FUNCTION_CODE_EXCEPTION;
+				break;
+				case BadDataLengthException:
+					return STR_BAD_DATA_LENGTH_EXCEPTION;
+				break;
+				case BadCRCException:
+					return STR_CRC_EXCEPTION;
+				break;
+			}
+
+			return STR_UNKNOWN_EXCEPTION;
+		}
+
 		inline void setTimeout(uint32_t timeout) {
 			_timeout = timeout;
 		}
 
+		inline bool hasException() {
+			return _exception != NoException;
+		}
+
+		inline enum Exceptions getException() {
+			return _exception;
+		}
+
+		inline void clearException() {
+			_exception = NoException;
+		}
+
 	protected:
+		inline void setException(enum Exceptions e) {
+			_exception = e;
+		}
+
 		inline uint8_t getState() const {
 			return _state;
 		}
@@ -43,6 +120,7 @@ class ModbusDevice {
 
 	private:
 		uint8_t _state;
+		enum Exceptions _exception = NoException;
 };
 
 class ModbusFrame {

--- a/src/ModbusRTUMaster.cpp
+++ b/src/ModbusRTUMaster.cpp
@@ -100,10 +100,8 @@ ModbusResponse ModbusRTUMaster::available() {
 		} else if (millis() - _lastRequestTime > _timeout) {
 			// Response timeout error
 			setState(Idle);
-#ifdef DEBUG
-			Serial.println("----- TIMEOUT -----");
-#endif
-			// TODO notify to user: timeout
+
+			setException(TimeoutException);
 		}
 	}
 
@@ -114,10 +112,7 @@ ModbusResponse ModbusRTUMaster::available() {
 				if (_next - _adu >= MODBUS_RTU_ADU_SIZE) {
 					// Overflow error
 					setState(Idle);
-#ifdef DEBUG
-					Serial.println("----- OVERFLOW -----");
-#endif
-					// TODO notify to user
+					setException(OverflowException);
 					break;
 				}
 				*_next++ = _serial.read();
@@ -133,32 +128,20 @@ ModbusResponse ModbusRTUMaster::available() {
 			// Check errors
 			if (responseLen < 3) {
 				// Bad length error
-				// TODO notify to user
-#if DEBUG
-				Serial.println("Modbus bad length");
-#endif
+				setException(BadDataLengthException);
 			} else {
 				// Calculate CRC of the response
 				uint16_t crc = crc16(_adu, responseLen - 2);
 				uint16_t responseCRC = (uint16_t(*(_next - 2)) << 8) | (*(_next - 1));
 				if (crc != responseCRC) {
 					// Invalid CRC error
-					// TODO notify to user
-#if DEBUG
-					Serial.println("Modbus invalid CRC");
-#endif
+					setException(BadCRCException);
 				} else if (_adu[0] != _currentSlave) {
 					// Bad slave error
-					// TODO notify to user
-#if DEBUG
-					Serial.println("Modbus bad slave error");
-#endif
+					setException(BadSlaveErrorException);
 				} else if (_adu[1] != _currentFC) {
 					// Bad function code
-					// TODO notify to user
-#if DEBUG
-					Serial.println("Modbus bad function code");
-#endif
+					setException(BadFunctionCodeException);
 				} else {
 					// TODO Check data length
 

--- a/src/ModbusTCPMaster.cpp
+++ b/src/ModbusTCPMaster.cpp
@@ -125,7 +125,8 @@ ModbusResponse ModbusTCPMaster::available() {
 					if (responseLen >= MODBUS_TCP_ADU_SIZE) {
 						// Overflow error
 						setState(Idle);
-						// TODO notify to user
+
+						setException(OverflowException);
 						break;
 					}
 
@@ -143,16 +144,16 @@ ModbusResponse ModbusTCPMaster::available() {
 							uint16_t transactionID = (_adu[0] << 8) + _adu[1];
 							if (transactionID != _currentTransactionID) {
 								// Invalid transaction ID
-								// TODO notify to user
+								setException(InvalidTransactionIdException);
 							} else if (_adu[2] != 0x00 && _adu[3] != 0x00) {
 								// Invalid protocol ID
-								// TODO notify to user
+								setException(InvalidProtocolIdException);
 							} else if (_adu[6] != _currentSlave) {
 								// Bad slave error
-								// TODO notify to user
+								setException(BadSlaveErrorException);
 							} else if ((_adu[7] & 0x7f) != _currentFC) {
 								// Bad function code
-								// TODO notify to user
+								setException(BadFunctionCodeException);
 							} else {
 								// TODO Check data length
 
@@ -168,7 +169,7 @@ ModbusResponse ModbusTCPMaster::available() {
 			} else if (millis() - _lastRequestTime > _timeout) {
 				// Response timeout error
 				setState(Idle);
-				// TODO notify to user
+				setException(TimeoutException);
 			}
 		}
 	}


### PR DESCRIPTION
I added a separate exceptions handler for managing error conditions such as timeout and invalid functions.

To make it so that existing code is not affected I choose to add a few new methods;

* hasException
* getException
* setException (private)
* clearException
* getExceptionMessage

These are part of the ModbusDevice class, and thus available to both ModbusRTUMaster and ModbusTCPMaster.

Before a new request, the code has to use `clearException`. Then after each execution of `.available()` the code should check `hasException` to ensure that no exception has occurred. I had to solve it this way since the ModbusResponse returned from `available()` has to do with protocol errors, not with exceptions of the sorts like a timeout.